### PR TITLE
New dif procedure

### DIFF
--- a/dataintegrityfingerprint/__init__.py
+++ b/dataintegrityfingerprint/__init__.py
@@ -1,7 +1,7 @@
 __author__ = 'Oliver Lindemann <oliver@expyriment.org>, ' \
              'Florian Krause <florian@expyriment.org>'
 
-__version__ = '0.5.4'
+__version__ = '0.6.0'
 
 from sys import version_info as _vi
 if _vi.major< 3:

--- a/dataintegrityfingerprint/cli.py
+++ b/dataintegrityfingerprint/cli.py
@@ -5,6 +5,7 @@ import argparse
 from . import DataIntegrityFingerprint
 from . import __version__
 
+
 def run():
 
     def progress(count, total, status=''):
@@ -16,15 +17,19 @@ def run():
         sys.stdout.flush()
 
     parser = argparse.ArgumentParser(
-        description="Create a Data Integrity Fingerprint (DIF). v{0}".format(
-        __version__),
-        epilog="(c) O. Lindemann & F. Krause")
+        description="""Data Integrity Fingerprint (DIF)
+Python Reference Implementation v{0}""".format(__version__),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Authors:
+Oliver Lindemann <oliver@expyriment.org>
+Florian Krause <florian@expyriment.org""")
 
     parser.add_argument("PATH", nargs='?', default=None,
                         help="the path to the data folder or file")
-    parser.add_argument("-f", "--from-checksums-file", dest="fromchecksumsfile",
-                        action="store_true",
-                        help="Calculate dif from checksums file. PATH is a checksums file",
+    parser.add_argument("-f", "--from-checksums-file",
+                        dest="fromchecksumsfile", action="store_true",
+                        help="Calculate dif from checksums file. " +
+                             "PATH is a checksums file",
                         default=False)
     parser.add_argument("-a", "--algorithm", metavar="ALGORITHM",
                         type=str,
@@ -46,13 +51,14 @@ def run():
                         action="store_true",
                         help="print available algorithms",
                         default=False)
-    parser.add_argument("-s", "--save-checksums-file", dest="savechecksumsfile",
-                        action="store_true",
+    parser.add_argument("-s", "--save-checksums-file",
+                        dest="savechecksumsfile", action="store_true",
                         help="save checksums to file",
                         default=False)
     parser.add_argument("-d", "--diff-checksums-file", metavar="CHECKSUMSFILE",
                         type=str,
-                        help="Calculate differences of checksums file to CHECKSUMSFILE")
+                        help="Calculate differences of checksums file to " +
+                             "CHECKSUMSFILE")
     parser.add_argument("-n", "--no-multi-processing", dest="nomultiprocess",
                         action="store_true",
                         help="switch of multi processing",
@@ -64,10 +70,10 @@ def run():
     parser.add_argument("--non-crypthographic",
                         dest="noncrypto",
                         action="store_true",
-                        help="allow non crypthographic algorithms (Not suggested, please " +
-                             "read documentation carefully!) ",
+                        help="allow non crypthographic algorithms " +
+                             "(Not suggested, please read documentation " +
+                             "carefully!)",
                         default=False)
-
     args = vars(parser.parse_args())
 
     if args['listalgos']:
@@ -100,7 +106,7 @@ def run():
         dif.generate(progress=progress)
         print("")
 
-    #output
+    # Output
     if args['savechecksumsfile']:
         outfile = os.path.split(
             dif.data)[-1] + ".{0}".format(dif._hash_algorithm)
@@ -124,14 +130,12 @@ def run():
     elif args['checksums']:
         print(dif.checksums.strip())
     else:
-        print("Data Integrity Fingerprint (DIF) v{0}".format(__version__))
-
-        print("\nFolder: {0}".format(dif.data))
+        print("Data Integrity Fingerprint (DIF)".format(__version__))
+        print("")
+        print("Folder: {0}".format(dif.data))
         print("Files: {0} included".format(dif.count_files()))
         print("Algorithm: {0}".format(dif.hash_algorithm))
         print("DIF: {}".format(dif))
-
-
 
 
 if __name__ == "__main__":

--- a/dataintegrityfingerprint/dif.py
+++ b/dataintegrityfingerprint/dif.py
@@ -104,7 +104,7 @@ class DataIntegrityFingerprint:
     @property
     def checksums(self):
         rtn = ""
-        for h, fl in self.file_hash_list:
+        for h, fl in sorted(self.file_hash_list, key=lambda x: x[1]):
             rtn += u"{0}{1}{2}\n".format(h, self.CHECKSUM_FILENAME_SEPARATOR,
                                          fl)
         return rtn
@@ -116,7 +116,8 @@ class DataIntegrityFingerprint:
 
         hasher = new_hash_instance(self._hash_algorithm,
                                    self.allow_non_cryptographic_algorithms)
-        hasher.update(self.checksums.encode("utf-8"))
+        concat = "".join(["".join(x) for x in self.file_hash_list])
+        hasher.update(concat.encode("utf-8"))
         return hasher.checksum
 
     def count_files(self):

--- a/dataintegrityfingerprint/dif.py
+++ b/dataintegrityfingerprint/dif.py
@@ -30,7 +30,6 @@ class DataIntegrityFingerprint:
 
     CRYPTOGRAPHIC_ALGORITHMS = OpenSSLHashAlgorithm.SUPPORTED_ALGORITHMS
     NON_CRYPTOGRAPHIC_ALGORITHMS = ZlibHashAlgorithm.SUPPORTED_ALGORITHMS
-    SEPARATOR = "_"
     CHECKSUM_FILENAME_SEPARATOR = "  "
 
     def __init__(self, data, from_checksums_file=False,
@@ -111,11 +110,7 @@ class DataIntegrityFingerprint:
         return rtn
 
     @property
-    def prefix(self):
-        return "".join(x for x in self.hash_algorithm.lower() if x.isalnum())
-
-    @property
-    def postfix(self):
+    def dif(self):
         if len(self.file_hash_list) < 1:
             return None
 
@@ -124,14 +119,8 @@ class DataIntegrityFingerprint:
         hasher.update(self.checksums.encode("utf-8"))
         return hasher.checksum
 
-    @property
-    def dif(self):
-        if self.postfix is not None:
-            return self.prefix + self.SEPARATOR + self.postfix
-
     def count_files(self):
-        """Returns the number of files that are included in the dif
-        """
+        """Return the number of files that are included in the dif."""
 
         return len(self.get_files())
 

--- a/dataintegrityfingerprint/gui.py
+++ b/dataintegrityfingerprint/gui.py
@@ -17,6 +17,7 @@ import tkinter as tk
 import tkinter.ttk as ttk
 from tkinter import filedialog, messagebox
 
+from . import __version__
 from .dif import DataIntegrityFingerprint as DIF
 from .dif import new_hash_instance
 
@@ -30,13 +31,12 @@ class App(ttk.Frame):
         self.master = master
         self.master.title("Data Integrity Fingerprint (DIF)")
         self.about_text = """Data Integrity Fingerprint (DIF)
-
-Reference Python implementation
+Reference Python implementation v{0}
 
 Authors:
 Oliver Lindemann <oliver@expyriment.org>
 Florian Krause <florian@expyriment.org>
-"""
+""".format(__version__)
         self.dif = None
         self.create_widgets()
         self.dir_button.focus()
@@ -88,6 +88,7 @@ Florian Krause <florian@expyriment.org>
         self.algorithm_menu = tk.Menu(self.menubar)
         self.algorithm_var = tk.StringVar()
         self.algorithm_var.set("SHA-256")
+        self.algorithm_var.trace('w', self.set_dif_label)
         for algorithm in DIF.CRYPTOGRAPHIC_ALGORITHMS:
             self.algorithm_menu.add_radiobutton(label=algorithm,
                                                 value=algorithm,
@@ -172,8 +173,9 @@ Florian Krause <florian@expyriment.org>
         self.frame2 = ttk.Frame(self.master)
         self.frame2.grid(row=3, column=0, sticky="NSWE")
         self.frame2.grid_columnconfigure(1, weight=1)
-        self.dif_label = ttk.Label(self.frame2, text="DIF:")
+        self.dif_label = ttk.Label(self.frame2)
         self.dif_label.grid(row=0, column=0)
+        self.set_dif_label()
         self.dif_var = tk.StringVar()
         self.dif_var.set("")
         self.dif_entry = ttk.Entry(self.frame2, textvariable=self.dif_var,
@@ -207,6 +209,10 @@ Florian Krause <florian@expyriment.org>
             self.dif = None
             self.statusbar["text"] = "Ready"
             self.unblock_gui(enable_save_checksums=False)
+
+    def set_dif_label(self, *args):
+        self.dif_label.config(text="DIF ({0}):".format(
+            self.algorithm_var.get()))
 
     def block_gui(self):
         """Block GUI from user entry."""
@@ -266,6 +272,7 @@ Florian Krause <florian@expyriment.org>
         self.checksum_list.insert(1.0, self.dif.checksums.strip("\n"))
         self.checksum_list["state"] = tk.DISABLED
         self.dif_var.set(self.dif.dif)
+        self.set_dif_label()
         self.copy_button["state"] = tk.NORMAL
         self.copy_button.focus()
         self.statusbar["text"] = "Done"
@@ -304,6 +311,7 @@ Florian Krause <florian@expyriment.org>
                 self.checksum_list.delete(1.0, tk.END)
                 self.checksum_list.insert(1.0, checksums)
                 self.checksum_list["state"] = tk.DISABLED
+                self.set_dif_label()
                 self.dif_var.set(master_hash)
                 self.copy_button["state"] = tk.NORMAL
                 self.copy_button.focus()
@@ -322,7 +330,7 @@ Florian Krause <florian@expyriment.org>
         """Save checksums file."""
 
         if self.checksum_list.get(1.0, tk.END).strip("\n") != "":
-            algorithm = self.dif_var.get().split(DIF.SEPARATOR)[0]
+            algorithm = self.algorithm_var.get()
             extension = "".join(x for x in algorithm.lower() if x.isalnum())
             filename = filedialog.asksaveasfilename(
                 defaultextension=extension,

--- a/dataintegrityfingerprint/gui.py
+++ b/dataintegrityfingerprint/gui.py
@@ -211,7 +211,7 @@ Florian Krause <florian@expyriment.org>
             self.unblock_gui(enable_save_checksums=False)
 
     def set_dif_label(self, *args):
-        self.dif_label.config(text="DIF ({0}):".format(
+        self.dif_label.config(text="DIF [{0}]:".format(
             self.algorithm_var.get()))
 
     def block_gui(self):


### PR DESCRIPTION
This will calculate the DIF as a direct concatenation without separators and newlines, as suggested here: https://github.com/expyriment/DIF/issues/12#issuecomment-843078287.

Checksum lists/files will include the separators and newlines, and will be sorted by file path only (unlike the DIF itself which is sorted by the concatenation of hex digest and file path) for readability. When calculating the DIF from such a checksum file, the lines are sorted (by full line value, i.e. hex digest and file path), and separators and newlines are stripped.
